### PR TITLE
cloudflareを使うためのTweak

### DIFF
--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -317,7 +317,9 @@ defmodule Plug.Static do
         apply(module, function, [path | args])
       nil ->
         file_info(size: size, mtime: mtime) = file_info
-        {size, mtime} |> :erlang.phash2() |> Integer.to_string(16)
+        tag = {size, mtime} |> :erlang.phash2() |> Integer.to_string(16)                                                                                                                                                                                                       
+        # want weak etag for cloudflare....                                                                                                                                                                                                                                 
+        "w\\\"" <> tag <> "\""          
     end
   end
 

--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -319,7 +319,7 @@ defmodule Plug.Static do
         file_info(size: size, mtime: mtime) = file_info
         tag = {size, mtime} |> :erlang.phash2() |> Integer.to_string(16)                                                                                                                                                                                                       
         # want weak etag for cloudflare....                                                                                                                                                                                                                                 
-        "w/\"" <> tag <> "\""          
+        "W/\"" <> tag <> "\""          
     end
   end
 

--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -319,7 +319,7 @@ defmodule Plug.Static do
         file_info(size: size, mtime: mtime) = file_info
         tag = {size, mtime} |> :erlang.phash2() |> Integer.to_string(16)                                                                                                                                                                                                       
         # want weak etag for cloudflare....                                                                                                                                                                                                                                 
-        "w\\\"" <> tag <> "\""          
+        "w/\"" <> tag <> "\""          
     end
   end
 


### PR DESCRIPTION
## わーくあらんど

cloudflareは無料プランだと弱いEtagしかサポートしていない。(強いEtagはEnterpriseプランでかなり高そう)

plugはファイルサイズと最終更新時刻を元に算出しているハッシュ値に"W/"を付与して無理やり弱いEtagにした。

CloudflareからEtagが返ってくることを確認した。


## 残課題

Browser cashe ttlは最短で30minのため問題は解決していない。
angularでassetのrevisioningはフォローしない方針のようなので個別にwebpackで設定する予定
https://github.com/angular/angular-cli/issues/1817